### PR TITLE
Fix velox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,91 @@
-dist
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+
+# C extensions
+*.c
+*.o
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+*.manifest
+*.spec
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Jupyter Notebook
 .ipynb_checkpoints
-*.egg-info
+*.ipynb
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# Virtual environments
+venv/
+ENV/
+env/
+.venv
+env.bak/
+venv.bak/
+
+# IDEs and editors
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+.DS_Store
+*.sublime-project
+*.sublime-workspace
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Environment variables
+.env
+.env.local
+.env.*.local
+
+# OS
+Thumbs.db
+.DS_Store

--- a/TemDataBrowser/__init__.py
+++ b/TemDataBrowser/__init__.py
@@ -81,14 +81,17 @@ class TemView(DataBrowserView):
         """  A new file has been selected by the user, load and display it
         """
         try:
+            is_stemtomo = False
             if Path(fname).suffix.lower() == '.emd':
                 # Check for special STEMTomo7 Berkeley EMD files
-                is_stemtomo = False
-                if Path(fname).suffix.lower() == '.emd':
+                try:
                     with ncempy.io.emd.fileEMD(fname) as f0:
                         if 'data' in f0.file_hdl:
                             if 'stemtomo version' in f0.file_hdl['data'].attrs:
                                 is_stemtomo = True
+                except ncempy.io.emd.NoEmdDataSets:
+                    # Velox files throw this error, they are not Berkeley EMD files
+                    is_stemtomo = False
             
             file = ncempy.read(fname)
             

--- a/TemDataBrowser/__init__.py
+++ b/TemDataBrowser/__init__.py
@@ -82,6 +82,7 @@ class TemView(DataBrowserView):
         """
         try:
             is_stemtomo = False
+            print(f'Loading {fname}...')
             if Path(fname).suffix.lower() == '.emd':
                 # Check for special STEMTomo7 Berkeley EMD files
                 try:
@@ -230,7 +231,8 @@ class TemMetadataView(DataBrowserView):
         if hasattr(mrc1, 'FEIinfo'):
             # add in the special FEIinfo if it exists
             try:
-                metaData.update(mrc1.FEIinfo)
+                if isinstance(mrc1.FEIinfo, dict):
+                    metaData.update(mrc1.FEIinfo)
             except TypeError:
                 pass
 
@@ -313,6 +315,8 @@ class TemMetadataView(DataBrowserView):
         import json
         metaData = {}
         with ncempy.io.emdVelox.fileEMDVelox(path) as f0:
+            if f0.list_data is None:
+                return metaData
             dataGroup = f0.list_data[0]
             dataset0 = dataGroup['Data']
 
@@ -402,11 +406,17 @@ class TemMetadataView(DataBrowserView):
         elif ext in ('.mrc', '.rec', '.ali'):
             meta_data = self.get_mrc_metadata(fname)
         elif ext in ('.emd',):
-            with ncempy.io.emd.fileEMD(fname) as emd0:
-                if len(emd0.list_emds) > 0:
-                    meta_data = self.get_emd_metadata(fname)
-                else:
-                    meta_data = self.get_velox_metadata(fname)
+            try: 
+                # Parse the file to see if any EMD datasets exist
+                # if not then it throws a NoEmdDataSets error
+                with ncempy.io.emd.fileEMD(fname) as f0:
+                    meta_data = f0.getMetadata(0)
+            except ncempy.io.emd.NoEmdDataSets:
+                with ncempy.io.emdVelox.fileEMDVelox(fname) as f0:
+                    if f0.list_data is not None:
+                        meta_data = f0.getMetadata(0)
+                    else:
+                        meta_data = {'file name': str(fname), 'error': 'No EMD datasets found'}
         elif ext in ('.ser',):
             meta_data = self.get_ser_metadata(fname)
         elif ext in ('.emi',):

--- a/TemDataBrowser/__init__.py
+++ b/TemDataBrowser/__init__.py
@@ -313,12 +313,12 @@ class TemMetadataView(DataBrowserView):
         import json
         metaData = {}
         with ncempy.io.emdVelox.fileEMDVelox(path) as f0:
-            dataGroup = emd_obj.list_data[0]
+            dataGroup = f0.list_data[0]
             dataset0 = dataGroup['Data']
 
             # Convert JSON metadata to dict
-            mData = emd_obj.list_data[0]['Metadata'][:, 0]
-            validMetaDataIndex = npwhere(mData > 0)  # find valid metadata
+            mData = f0.list_data[0]['Metadata'][:, 0]
+            validMetaDataIndex = np.where(mData > 0)  # find valid metadata
             mData = mData[validMetaDataIndex].tostring()  # change to string
             mDataS = json.loads(mData.decode('utf-8', 'ignore'))  # load UTF-8 string as JSON and output dict
             metaData['pixel sizes'] = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,9 +7,9 @@ name = "TemDataBrowser"
 authors = [{name = "Peter Ercius", email="percius@lbl.gov"}]
 description = "Graphical user interface to view transmission electron microscopy data."
 readme = "README.md"
-requires-python = ">=3.8"
-dependencies = ["numpy","pyqtgraph","ScopeFoundry>=1.5","ncempy","scipy","imageio>2.17"]
-version = "1.0.6"
+requires-python = ">=3.10"
+dependencies = ["numpy","pyqtgraph","ScopeFoundry>=1.5","ncempy>=1.15","scipy","imageio>2.17"]
+version = "1.1"
 
 [project.scripts]
 TemDataBrowser = "TemDataBrowser:open_file"


### PR DESCRIPTION
Velox files would not load because of the checking for STEMTomo7. See #9. This fixes that problem and a similar problem found in the metadata viewer for the same files.

I also bumped several python package versions ready for a 1.1 release of this program.