### PR TITLE
Update workflow to use Node.js 24 for GitHub Actions

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -2,6 +2,9 @@ name: Publish Python distribution to Pypi and testpypi
 
 on: push
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build:
     name: Build distribution


### PR DESCRIPTION
Set FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true to opt into Node.js 24 ahead of the June 2026 forced migration, resolving deprecation warnings for actions/checkout@v4, actions/setup-python@v5, and actions/upload-artifact@v4.